### PR TITLE
purging spotless entirely

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -25,9 +25,3 @@ jobs:
 
       - name: Verify that the java code compiles
         run: ./gradlew --console=verbose build
-
-      # Disabling spotless from the build check.
-      # This can be run as needed with `./gradlew :spotlessCheck` in the terminal
-      # but will not block pr merges. 
-      # - name: Run the spotless check to make sure the format of the code looks fine
-      #   run: ./gradlew :spotlessCheck

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id "java"
     id "edu.wpi.first.GradleRIO" version "2022.3.1"
-    id "com.diffplug.spotless" version "6.2.0"
 }
 
 sourceCompatibility = JavaVersion.VERSION_11
@@ -86,11 +85,3 @@ jar {
 deployArtifact.jarTask = jar
 wpi.java.configureExecutableTasks(jar)
 wpi.java.configureTestTasks(test)
-
-apply plugin: 'com.diffplug.spotless'
-spotless {
-    java {
-        importOrder 'java', 'javax', 'org', 'com', ''
-        removeUnusedImports()
-    }
-}


### PR DESCRIPTION
purging spotless since it gets called on `./gradlew build` as well.